### PR TITLE
Fix import path for useAuth

### DIFF
--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,7 +1,8 @@
 import { NavLink } from 'react-router-dom';
 import { Home, Package, Users, Settings } from 'lucide-react';
 
-import useAuth from '@/hooks/useAuth'; // We will use this soon
+// useAuth is provided by the AuthContext
+import { useAuth } from '@/contexts/AuthContext';
 
 // This function correctly applies classes for active/inactive links
 const navLinkClasses = ({ isActive }) =>


### PR DESCRIPTION
## Summary
- fix Sidebar import to useAuth from `AuthContext`

## Testing
- `pnpm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685af4c4b7888327bc9f18c0b0bd0932